### PR TITLE
fix: trigger footer hash update even in scrolling event listener

### DIFF
--- a/templates/deals_template.html
+++ b/templates/deals_template.html
@@ -131,6 +131,12 @@
                     }
 
                     history.replaceState(null, null, new URL(newHash, window.location));
+
+                    // need to manually trigger the hashchange event, because replaceState
+                    // doesn't trigger it by itself
+                    if (updateHashLinks !== undefined) {
+                        updateHashLinks();
+                    }
                 });
             });
         });


### PR DESCRIPTION
This fixes the issue in https://github.com/rugk/neotaste_scraper/pull/34 that auto-scroll events did not update the footer links